### PR TITLE
Add docker compose for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+deno-dir

--- a/README.md
+++ b/README.md
@@ -31,12 +31,22 @@ it's opinionated. You'll notice these choices:
   thing
 - No creepy analytics
 
-## Running & Deploying
+## Running 
 
+### With Deno
 1. Get [Deno](https://deno.land)
-2. `cd` to local clone or fork
-3. `deno task serve`
-4. `deno run --allow-all --unstable deploy.ts`
+1. `cd` to local clone or fork
+1. `deno task serve`
+
+### With Docker Compose
+1. Get [Docker](https://www.docker.com)
+1. `cd` to local clone or fork
+1. `docker-compose up`
+
+## Deploying
+1. Get [Deno](https://deno.land)
+1. `cd` to local clone or fork
+1. `deno run --allow-all --unstable deploy.ts`
 
 `deploy.ts` is hard-coded for deploying my website to GitHub Pages—you'll want
 to modify it for your purposes, along with configuration and metadata. And

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ it's opinionated. You'll notice these choices:
 
 ## Running & Deploying
 
-1. Get [Deno](https://deno.land) and [Lume](https://lume.land)
+1. Get [Deno](https://deno.land)
 2. `cd` to local clone or fork
-3. `lume --serve`
+3. `deno task serve`
 4. `deno run --allow-all --unstable deploy.ts`
 
 `deploy.ts` is hard-coded for deploying my website to GitHub Pages—you'll want

--- a/_config.ts
+++ b/_config.ts
@@ -9,28 +9,23 @@ import metas from "lume/plugins/metas.ts";
 import date from "lume/plugins/date.ts";
 import md from "https://jspm.dev/markdown-it-container";
 
-const site = lume({
-  src: "./src",
-}, {
-  markdown: {
-    plugins: [md],
+const site = lume(
+  {
+    src: "./src",
   },
-});
-
-const mdInstance = site.formats.get(".md").engine;
-
-// Add `target="_blank"` to all Markdown links:
-// TODO: Use new feature added per https://github.com/lumeland/lume/issues/218.
-mdInstance.engine.renderer.rules.link_open = (
-  tokens,
-  idx,
-  options,
-  env,
-  self,
-) => {
-  tokens[idx].attrPush(["target", "_blank"]);
-  return self.renderToken(tokens, idx, options, env, self);
-};
+  {
+    markdown: {
+      plugins: [md],
+      rules: {
+        // Add `target="_blank"` to all Markdown links:
+        link_open: (tokens, idx, options, env, self) => {
+          tokens[idx].attrPush(["target", "_blank"]);
+          return self.renderToken(tokens, idx, options, env, self);
+        },
+      },
+    },
+  }
+);
 
 site.use(pug());
 site.use(relative_urls());

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,11 @@
+{
+  "tasks": {
+    "lume": "echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
+    "build": "deno task lume",
+    "serve": "deno task lume -s"
+  },
+  "imports": {
+    "lume/": "https://deno.land/x/lume@v1.18.5/"
+  },
+  "lock": false
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  blog:
+    container_name: blog
+    image: denoland/deno:1.36.4
+    restart: always
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: deno task serve
+    ports:
+      - 3000:3000
+    environment:
+      - DENO_DIR=/app/deno-dir


### PR DESCRIPTION
Work on top of https://github.com/reeseschultz/reese.codes/pull/1

# What
- Adds a `docker-compose.yml` file to be able to develop with Docker containers
  - I also added the `deno-dir` folder in order to be able to mount the modules to the container, so they don't get pulled every time
- I also had to add a `deno.json` because I wasn't able to make it work otherwise. Maybe this repo was being used with an older version? 

# Why
I want to be able to develop with the least amount of installation in my machine, and containers are the current standard for this