### PR TITLE
Deploy to Github Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,39 @@
+# copied from https://lume.land/docs/advanced/deployment/#github-pages
+name: Publish on GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Setup Deno environment
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Build site
+        run: deno task build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "_site"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
A nice automation :smile: 

Tested in my fork and the deployed app can be seen in https://agustinramirodiaz.github.io/reese.codes/

I'm pretty sure this requires setting the Github Pages deployment source to `Github Actions`

![image](https://github.com/reeseschultz/reese.codes/assets/49416765/402575b0-328f-411f-bce6-245f05ff0185)
